### PR TITLE
Fixes an issue where i64s are parsed as unsigned integers

### DIFF
--- a/src/from_value.rs
+++ b/src/from_value.rs
@@ -62,7 +62,7 @@ macro_rules! int_from_value {
         $(
             impl FromValue for $t {
                 fn from_value(value: Result<dynamic::ValueAccessor>) -> InputValueResult<Self> {
-                    Self::try_from(value?.u64()?).map_err(|_| {
+                    Self::try_from(value?.i64()?).map_err(|_| {
                         InputValueError::custom(format!(
                             "Only integers from {} to {} are accepted for {}.",
                             Self::MIN,


### PR DESCRIPTION
Was receiving errors like `Failed to parse \"Int\": internal: not an unsigned integer` when trying to send negative integers to `i64` fields