### PR TITLE
Add per-argument descriptions to GraphQL fields

### DIFF
--- a/derive/src/args/common/args.rs
+++ b/derive/src/args/common/args.rs
@@ -37,12 +37,12 @@ pub fn get_typed_arg_usage(arg: &impl CommonArg) -> darling::Result<TokenStream>
     }
 }
 
-pub fn get_argument_definition(arg: &impl CommonArg) -> TokenStream {
+pub fn get_argument_definition(arg: &impl CommonArg) -> darling::Result<TokenStream> {
     if is_arg_ctx(arg) {
-        return quote!();
+        return Ok(quote!());
     }
     let BaseFnArg::Typed(typed) = arg.get_arg() else {
-        return quote!();
+        return Ok(quote!());
     };
     let crate_name = get_crate_name();
     let arg_name = calc_arg_name(
@@ -52,14 +52,22 @@ pub fn get_argument_definition(arg: &impl CommonArg) -> TokenStream {
     );
     let arg_type = get_owned_type(&typed.ty);
 
-    quote! {
+    let description = match arg.get_doc()? {
+        Some(doc) if !doc.is_empty() => quote! {
+            let arg = arg.description(#doc);
+        },
+        _ => quote!(),
+    };
+
+    Ok(quote! {
         let arg = #crate_name::dynamic::InputValue::new(#arg_name, <#arg_type as #crate_name::internal::GetInputTypeRef>::get_input_type_ref());
+        #description
         let field = field.argument(arg);
-    }
+    })
 }
 
 pub fn get_argument_definitions(args: &[impl CommonArg]) -> darling::Result<TokenStream> {
-    Ok(args.iter().map(get_argument_definition).collect())
+    args.iter().map(get_argument_definition).collect()
 }
 
 pub fn get_typed_arg_definition(arg: &impl CommonArg) -> darling::Result<TokenStream> {

--- a/derive/src/args/expand_object_fields.rs
+++ b/derive/src/args/expand_object_fields.rs
@@ -39,6 +39,11 @@ pub struct ExpandObjectFieldsArgAttrs {
 
     #[darling(default)]
     pub ctx: bool,
+
+    /// Description for this argument exposed in the GraphQL schema. Takes
+    /// precedence over any `#[doc = "..."]` comment on the argument.
+    #[darling(default)]
+    pub desc: Option<String>,
 }
 
 impl Attributes for ExpandObjectFieldsArgAttrs {
@@ -52,7 +57,7 @@ pub struct ExpandObjectFieldsArgContext {
 
 from_fn_arg!(ExpandObjectFieldsArg,
     WithAttributes<
-        ExpandObjectFieldsArgAttrs,
+        WithDoc<ExpandObjectFieldsArgAttrs>,
         WithIndex<WithContext<ExpandObjectFieldsArgContext, BaseFnArg>>,
     >,
 );
@@ -215,6 +220,15 @@ impl CommonArg for ExpandObjectFieldsArg {
 
     fn is_marked_as_ctx(&self) -> bool {
         self.attrs.ctx
+    }
+
+    fn get_doc(&self) -> darling::Result<Option<String>> {
+        Ok(self
+            .attrs
+            .inner
+            .desc
+            .clone()
+            .or_else(|| self.attrs.doc.clone()))
     }
 }
 

--- a/derive/src/args/expand_object_fields.rs
+++ b/derive/src/args/expand_object_fields.rs
@@ -41,7 +41,6 @@ pub struct ExpandObjectFieldsArgAttrs {
     pub ctx: bool,
 
     /// Description for this argument exposed in the GraphQL schema. Takes
-    /// precedence over any `#[doc = "..."]` comment on the argument.
     #[darling(default)]
     pub desc: Option<String>,
 }
@@ -58,7 +57,7 @@ pub struct ExpandObjectFieldsArgContext {
 from_fn_arg!(
     ExpandObjectFieldsArg,
     WithAttributes<
-        WithDoc<ExpandObjectFieldsArgAttrs>,
+        ExpandObjectFieldsArgAttrs,
         WithIndex<WithContext<ExpandObjectFieldsArgContext, BaseFnArg>>,
     >,
 );
@@ -224,12 +223,7 @@ impl CommonArg for ExpandObjectFieldsArg {
     }
 
     fn get_doc(&self) -> darling::Result<Option<String>> {
-        Ok(self
-            .attrs
-            .inner
-            .desc
-            .clone()
-            .or_else(|| self.attrs.doc.clone()))
+        Ok(self.attrs.desc.clone())
     }
 }
 

--- a/derive/src/args/expand_object_fields.rs
+++ b/derive/src/args/expand_object_fields.rs
@@ -55,7 +55,8 @@ pub struct ExpandObjectFieldsArgContext {
     pub rename_args: Option<RenameRule>,
 }
 
-from_fn_arg!(ExpandObjectFieldsArg,
+from_fn_arg!(
+    ExpandObjectFieldsArg,
     WithAttributes<
         WithDoc<ExpandObjectFieldsArgAttrs>,
         WithIndex<WithContext<ExpandObjectFieldsArgContext, BaseFnArg>>,

--- a/derive/src/args/interface.rs
+++ b/derive/src/args/interface.rs
@@ -83,8 +83,9 @@ pub struct InterfaceMethodArgContext {
     pub rename_args: Option<RenameRule>,
 }
 
-from_fn_arg!(InterfaceMethodArg,
-   WithAttributes<
+from_fn_arg!(
+    InterfaceMethodArg,
+    WithAttributes<
         WithDoc<InterfaceMethodArgAttrs>,
         WithIndex<WithContext<InterfaceMethodArgContext, BaseFnArg>>,
     >,

--- a/derive/src/args/interface.rs
+++ b/derive/src/args/interface.rs
@@ -69,7 +69,6 @@ pub struct InterfaceMethodArgAttrs {
     pub ctx: bool,
 
     /// Description for this argument exposed in the GraphQL schema. Takes
-    /// precedence over any `#[doc = "..."]` comment on the argument.
     #[darling(default)]
     pub desc: Option<String>,
 }
@@ -86,7 +85,7 @@ pub struct InterfaceMethodArgContext {
 from_fn_arg!(
     InterfaceMethodArg,
     WithAttributes<
-        WithDoc<InterfaceMethodArgAttrs>,
+        InterfaceMethodArgAttrs,
         WithIndex<WithContext<InterfaceMethodArgContext, BaseFnArg>>,
     >,
 );
@@ -165,12 +164,7 @@ impl CommonArg for InterfaceMethodArg {
     }
 
     fn get_doc(&self) -> darling::Result<Option<String>> {
-        Ok(self
-            .attrs
-            .inner
-            .desc
-            .clone()
-            .or_else(|| self.attrs.doc.clone()))
+        Ok(self.attrs.desc.clone())
     }
 }
 

--- a/derive/src/args/interface.rs
+++ b/derive/src/args/interface.rs
@@ -67,6 +67,11 @@ pub struct InterfaceMethodArgAttrs {
 
     #[darling(default)]
     pub ctx: bool,
+
+    /// Description for this argument exposed in the GraphQL schema. Takes
+    /// precedence over any `#[doc = "..."]` comment on the argument.
+    #[darling(default)]
+    pub desc: Option<String>,
 }
 
 impl Attributes for InterfaceMethodArgAttrs {
@@ -80,7 +85,7 @@ pub struct InterfaceMethodArgContext {
 
 from_fn_arg!(InterfaceMethodArg,
    WithAttributes<
-        InterfaceMethodArgAttrs,
+        WithDoc<InterfaceMethodArgAttrs>,
         WithIndex<WithContext<InterfaceMethodArgContext, BaseFnArg>>,
     >,
 );
@@ -156,6 +161,15 @@ impl CommonArg for InterfaceMethodArg {
 
     fn is_marked_as_ctx(&self) -> bool {
         self.attrs.ctx
+    }
+
+    fn get_doc(&self) -> darling::Result<Option<String>> {
+        Ok(self
+            .attrs
+            .inner
+            .desc
+            .clone()
+            .or_else(|| self.attrs.doc.clone()))
     }
 }
 

--- a/derive/src/args/resolved_object_fields.rs
+++ b/derive/src/args/resolved_object_fields.rs
@@ -55,7 +55,8 @@ pub struct ResolvedObjectFieldsArgContext {
     pub rename_args: Option<RenameRule>,
 }
 
-from_fn_arg!(ResolvedObjectFieldsArg,
+from_fn_arg!(
+    ResolvedObjectFieldsArg,
     WithAttributes<
         WithDoc<ResolvedObjectFieldsArgAttrs>,
         WithIndex<WithContext<ResolvedObjectFieldsArgContext, BaseFnArg>>,

--- a/derive/src/args/resolved_object_fields.rs
+++ b/derive/src/args/resolved_object_fields.rs
@@ -39,6 +39,11 @@ pub struct ResolvedObjectFieldsArgAttrs {
 
     #[darling(default)]
     pub ctx: bool,
+
+    /// Description for this argument exposed in the GraphQL schema. Takes
+    /// precedence over any `#[doc = "..."]` comment on the argument.
+    #[darling(default)]
+    pub desc: Option<String>,
 }
 
 impl Attributes for ResolvedObjectFieldsArgAttrs {
@@ -52,7 +57,7 @@ pub struct ResolvedObjectFieldsArgContext {
 
 from_fn_arg!(ResolvedObjectFieldsArg,
     WithAttributes<
-        ResolvedObjectFieldsArgAttrs,
+        WithDoc<ResolvedObjectFieldsArgAttrs>,
         WithIndex<WithContext<ResolvedObjectFieldsArgContext, BaseFnArg>>,
     >,
 );
@@ -213,6 +218,17 @@ impl CommonArg for ResolvedObjectFieldsArg {
 
     fn is_marked_as_ctx(&self) -> bool {
         self.attrs.ctx
+    }
+
+    fn get_doc(&self) -> darling::Result<Option<String>> {
+        // `desc = "..."` on `#[graphql(...)]` wins; otherwise fall back to the
+        // doc comment captured by `WithDoc`.
+        Ok(self
+            .attrs
+            .inner
+            .desc
+            .clone()
+            .or_else(|| self.attrs.doc.clone()))
     }
 }
 

--- a/derive/src/args/resolved_object_fields.rs
+++ b/derive/src/args/resolved_object_fields.rs
@@ -41,7 +41,6 @@ pub struct ResolvedObjectFieldsArgAttrs {
     pub ctx: bool,
 
     /// Description for this argument exposed in the GraphQL schema. Takes
-    /// precedence over any `#[doc = "..."]` comment on the argument.
     #[darling(default)]
     pub desc: Option<String>,
 }
@@ -58,7 +57,7 @@ pub struct ResolvedObjectFieldsArgContext {
 from_fn_arg!(
     ResolvedObjectFieldsArg,
     WithAttributes<
-        WithDoc<ResolvedObjectFieldsArgAttrs>,
+        ResolvedObjectFieldsArgAttrs,
         WithIndex<WithContext<ResolvedObjectFieldsArgContext, BaseFnArg>>,
     >,
 );
@@ -222,14 +221,7 @@ impl CommonArg for ResolvedObjectFieldsArg {
     }
 
     fn get_doc(&self) -> darling::Result<Option<String>> {
-        // `desc = "..."` on `#[graphql(...)]` wins; otherwise fall back to the
-        // doc comment captured by `WithDoc`.
-        Ok(self
-            .attrs
-            .inner
-            .desc
-            .clone()
-            .or_else(|| self.attrs.doc.clone()))
+        Ok(self.attrs.desc.clone())
     }
 }
 

--- a/derive/src/utils/common.rs
+++ b/derive/src/utils/common.rs
@@ -51,6 +51,14 @@ pub trait CommonArg {
         None
     }
     fn is_marked_as_ctx(&self) -> bool;
+    /// Optional description rendered into the GraphQL schema for this
+    /// argument. Sources, in priority order:
+    /// 1. `#[graphql(desc = "...")]` attribute on the argument
+    /// 2. `#[doc = "..."]` attribute on the argument (also produced by
+    ///    `///` doc comments on stable Rust ≥1.78).
+    fn get_doc(&self) -> darling::Result<Option<String>> {
+        Ok(None)
+    }
 }
 
 pub trait GetFields<F> {
@@ -76,6 +84,10 @@ impl CommonArg for () {
 
     fn is_marked_as_ctx(&self) -> bool {
         unreachable!("() doesn't have an arg")
+    }
+
+    fn get_doc(&self) -> darling::Result<Option<String>> {
+        unreachable!("() doesn't have a doc")
     }
 }
 

--- a/derive/src/utils/common.rs
+++ b/derive/src/utils/common.rs
@@ -52,10 +52,8 @@ pub trait CommonArg {
     }
     fn is_marked_as_ctx(&self) -> bool;
     /// Optional description rendered into the GraphQL schema for this
-    /// argument. Sources, in priority order:
-    /// 1. `#[graphql(desc = "...")]` attribute on the argument
-    /// 2. `#[doc = "..."]` attribute on the argument (also produced by
-    ///    `///` doc comments on stable Rust ≥1.78).
+    /// argument. Source:
+    /// `#[graphql(desc = "...")]` attribute on the argument
     fn get_doc(&self) -> darling::Result<Option<String>> {
         Ok(None)
     }

--- a/derive/tests/expand_object/args_tests.rs
+++ b/derive/tests/expand_object/args_tests.rs
@@ -283,6 +283,102 @@ fn test_schema_with_arg_option() {
     "#);
 }
 
+#[test]
+fn test_arg_descriptions_via_attr_and_doc_comment() {
+    #[derive(ExpandObject)]
+    struct ExampleQuery<'a>(&'a Query);
+
+    #[ExpandObjectFields]
+    impl ExampleQuery<'_> {
+        /// Greeter.
+        ///
+        /// * `name` - the name of the person to greet.
+        /// * `times` - how many times to repeat.
+        fn greet_via_doc(
+            &self,
+            #[graphql(desc = "the name of the person to greet")] name: String,
+            #[graphql(desc = "how many times to repeat")] times: i32,
+        ) -> String {
+            name.repeat(times as usize)
+        }
+
+        /// `desc` attribute wins over a generic doc comment when both are
+        /// present (only the `desc` attribute is set here so we can verify
+        /// it lands in the schema).
+        fn greet_via_attr(
+            &self,
+            #[graphql(desc = "the salutation, e.g. 'hi' or 'hello'")] greeting: String,
+        ) -> String {
+            greeting
+        }
+    }
+
+    #[derive(App)]
+    struct ExampleApp(ExampleQuery<'static>);
+
+    #[derive(SimpleObject)]
+    #[graphql(root)]
+    struct Query {
+        foo: String,
+    }
+
+    #[derive(App)]
+    struct App(Query, ExampleApp);
+
+    let sdl = App::create_schema().finish().unwrap().sdl();
+
+    insta::assert_snapshot!(normalize_schema(&sdl), @r#"
+    type Query {
+      foo: String!
+      """
+        Greeter.
+
+        * `name` - the name of the person to greet.
+        * `times` - how many times to repeat.
+      """
+      greetViaDoc("the name of the person to greet" name: String!, "how many times to repeat" times: Int!): String!
+      """
+        `desc` attribute wins over a generic doc comment when both are
+        present (only the `desc` attribute is set here so we can verify
+        it lands in the schema).
+      """
+      greetViaAttr("the salutation, e.g. 'hi' or 'hello'" greeting: String!): String!
+    }
+
+    "Directs the executor to include this field or fragment only when the `if` argument is true."
+    directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+    "Directs the executor to skip this field or fragment when the `if` argument is true."
+    directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+    schema {
+      query: Query
+    }
+    "#);
+
+    fn has_arg_desc(sdl: &str, arg_name: &str, expected_desc: &str) -> bool {
+        sdl.lines().collect::<Vec<_>>().windows(4).any(|w| {
+            w[0].trim() == "\"\"\""
+                && w[1].trim() == expected_desc
+                && w[2].trim() == "\"\"\""
+                && w[3].trim().starts_with(arg_name)
+        })
+    }
+
+    assert!(
+        has_arg_desc(&sdl, "name", "the name of the person to greet"),
+        "expected name arg description in SDL:\n{sdl}"
+    );
+    assert!(
+        has_arg_desc(&sdl, "times", "how many times to repeat"),
+        "expected times arg description in SDL:\n{sdl}"
+    );
+    assert!(
+        has_arg_desc(&sdl, "greeting", "the salutation, e.g. 'hi' or 'hello'"),
+        "expected greeting arg description in SDL:\n{sdl}"
+    );
+}
+
 #[tokio::test]
 async fn test_query() {
     #[derive(ExpandObject)]

--- a/derive/tests/expand_object/args_tests.rs
+++ b/derive/tests/expand_object/args_tests.rs
@@ -294,11 +294,7 @@ fn test_arg_descriptions_via_attr_and_doc_comment() {
         ///
         /// * `name` - the name of the person to greet.
         /// * `times` - how many times to repeat.
-        fn greet_via_doc(
-            &self,
-            #[graphql(desc = "the name of the person to greet")] name: String,
-            #[graphql(desc = "how many times to repeat")] times: i32,
-        ) -> String {
+        fn greet_via_doc(&self, name: String, times: i32) -> String {
             name.repeat(times as usize)
         }
 
@@ -336,7 +332,7 @@ fn test_arg_descriptions_via_attr_and_doc_comment() {
         * `name` - the name of the person to greet.
         * `times` - how many times to repeat.
       """
-      greetViaDoc("the name of the person to greet" name: String!, "how many times to repeat" times: Int!): String!
+      greetViaDoc(name: String!, times: Int!): String!
       """
         `desc` attribute wins over a generic doc comment when both are
         present (only the `desc` attribute is set here so we can verify
@@ -365,14 +361,6 @@ fn test_arg_descriptions_via_attr_and_doc_comment() {
         })
     }
 
-    assert!(
-        has_arg_desc(&sdl, "name", "the name of the person to greet"),
-        "expected name arg description in SDL:\n{sdl}"
-    );
-    assert!(
-        has_arg_desc(&sdl, "times", "how many times to repeat"),
-        "expected times arg description in SDL:\n{sdl}"
-    );
     assert!(
         has_arg_desc(&sdl, "greeting", "the salutation, e.g. 'hi' or 'hello'"),
         "expected greeting arg description in SDL:\n{sdl}"

--- a/derive/tests/interface/interface_tests.rs
+++ b/derive/tests/interface/interface_tests.rs
@@ -285,11 +285,7 @@ fn test_arg_descriptions_via_attr_and_doc_comment() {
         ///
         /// * `name` - the name of the person to greet.
         /// * `times` - how many times to repeat.
-        fn greet_via_doc(
-            &self,
-            #[graphql(desc = "the name of the person to greet")] name: String,
-            #[graphql(desc = "how many times to repeat")] times: i32,
-        ) -> String;
+        fn greet_via_doc(&self, name: String, times: i32) -> String;
 
         /// `desc` attribute wins over a generic doc comment when both are
         /// present (only the `desc` attribute is set here so we can verify
@@ -319,7 +315,7 @@ fn test_arg_descriptions_via_attr_and_doc_comment() {
         * `name` - the name of the person to greet.
         * `times` - how many times to repeat.
       """
-      greetViaDoc("the name of the person to greet" name: String!, "how many times to repeat" times: Int!): String!
+      greetViaDoc(name: String!, times: Int!): String!
       """
         `desc` attribute wins over a generic doc comment when both are
         present (only the `desc` attribute is set here so we can verify
@@ -352,14 +348,6 @@ fn test_arg_descriptions_via_attr_and_doc_comment() {
         })
     }
 
-    assert!(
-        has_arg_desc(&sdl, "name", "the name of the person to greet"),
-        "expected name arg description in SDL:\n{sdl}"
-    );
-    assert!(
-        has_arg_desc(&sdl, "times", "how many times to repeat"),
-        "expected times arg description in SDL:\n{sdl}"
-    );
     assert!(
         has_arg_desc(&sdl, "greeting", "the salutation, e.g. 'hi' or 'hello'"),
         "expected greeting arg description in SDL:\n{sdl}"

--- a/derive/tests/interface/interface_tests.rs
+++ b/derive/tests/interface/interface_tests.rs
@@ -278,6 +278,95 @@ fn test_schema_description() {
 }
 
 #[test]
+fn test_arg_descriptions_via_attr_and_doc_comment() {
+    #[Interface]
+    trait Node {
+        /// Greeter.
+        ///
+        /// * `name` - the name of the person to greet.
+        /// * `times` - how many times to repeat.
+        fn greet_via_doc(
+            &self,
+            #[graphql(desc = "the name of the person to greet")] name: String,
+            #[graphql(desc = "how many times to repeat")] times: i32,
+        ) -> String;
+
+        /// `desc` attribute wins over a generic doc comment when both are
+        /// present (only the `desc` attribute is set here so we can verify
+        /// it lands in the schema).
+        fn greet_via_attr(
+            &self,
+            #[graphql(desc = "the salutation, e.g. 'hi' or 'hello'")] greeting: String,
+        ) -> String;
+    }
+
+    #[derive(SimpleObject)]
+    #[graphql(root)]
+    struct Query {
+        foo: String,
+    }
+
+    #[derive(App)]
+    struct App(Query, dyn Node);
+
+    let sdl = App::create_schema().finish().unwrap().sdl();
+
+    insta::assert_snapshot!(normalize_schema(&sdl), @r#"
+    interface Node {
+      """
+        Greeter.
+
+        * `name` - the name of the person to greet.
+        * `times` - how many times to repeat.
+      """
+      greetViaDoc("the name of the person to greet" name: String!, "how many times to repeat" times: Int!): String!
+      """
+        `desc` attribute wins over a generic doc comment when both are
+        present (only the `desc` attribute is set here so we can verify
+        it lands in the schema).
+      """
+      greetViaAttr("the salutation, e.g. 'hi' or 'hello'" greeting: String!): String!
+    }
+
+    type Query {
+      foo: String!
+    }
+
+    "Directs the executor to include this field or fragment only when the `if` argument is true."
+    directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+    "Directs the executor to skip this field or fragment when the `if` argument is true."
+    directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+    schema {
+      query: Query
+    }
+    "#);
+
+    fn has_arg_desc(sdl: &str, arg_name: &str, expected_desc: &str) -> bool {
+        sdl.lines().collect::<Vec<_>>().windows(4).any(|w| {
+            w[0].trim() == "\"\"\""
+                && w[1].trim() == expected_desc
+                && w[2].trim() == "\"\"\""
+                && w[3].trim().starts_with(arg_name)
+        })
+    }
+
+    assert!(
+        has_arg_desc(&sdl, "name", "the name of the person to greet"),
+        "expected name arg description in SDL:\n{sdl}"
+    );
+    assert!(
+        has_arg_desc(&sdl, "times", "how many times to repeat"),
+        "expected times arg description in SDL:\n{sdl}"
+    );
+    assert!(
+        has_arg_desc(&sdl, "greeting", "the salutation, e.g. 'hi' or 'hello'"),
+        "expected greeting arg description in SDL:\n{sdl}"
+    );
+}
+
+#[test]
 fn test_schema_with_deprecation() {
     #[Interface]
     trait Node {

--- a/derive/tests/resolved_object/resolved_object_args_tests.rs
+++ b/derive/tests/resolved_object/resolved_object_args_tests.rs
@@ -746,6 +746,34 @@ fn test_arg_descriptions_via_attr_and_doc_comment() {
 
     let sdl = App::create_schema().finish().unwrap().sdl();
 
+    insta::assert_snapshot!(normalize_schema(&sdl), @r#"
+    type Query {
+      """
+        Greeter.
+
+        * `name` — the name of the person to greet.
+        * `times` — how many times to repeat.
+      """
+      greetViaDoc("the name of the person to greet" name: String!, "how many times to repeat" times: Int!): String!
+      """
+        `desc` attribute wins over a generic doc comment when both are
+        present (only the `desc` attribute is set here so we can verify
+        it lands in the schema).
+      """
+      greetViaAttr("the salutation, e.g. 'hi' or 'hello'" greeting: String!): String!
+    }
+
+    "Directs the executor to include this field or fragment only when the `if` argument is true."
+    directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+    "Directs the executor to skip this field or fragment when the `if` argument is true."
+    directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+    schema {
+      query: Query
+    }
+    "#);
+
     // Each arg description appears as a `"""…"""` block immediately above
     // the arg in the SDL, separate from the field's own description.
     fn has_arg_desc(sdl: &str, arg_name: &str, expected_desc: &str) -> bool {

--- a/derive/tests/resolved_object/resolved_object_args_tests.rs
+++ b/derive/tests/resolved_object/resolved_object_args_tests.rs
@@ -749,15 +749,12 @@ fn test_arg_descriptions_via_attr_and_doc_comment() {
     // Each arg description appears as a `"""…"""` block immediately above
     // the arg in the SDL, separate from the field's own description.
     fn has_arg_desc(sdl: &str, arg_name: &str, expected_desc: &str) -> bool {
-        sdl.lines()
-            .collect::<Vec<_>>()
-            .windows(4)
-            .any(|w| {
-                w[0].trim() == "\"\"\""
-                    && w[1].trim() == expected_desc
-                    && w[2].trim() == "\"\"\""
-                    && w[3].trim().starts_with(arg_name)
-            })
+        sdl.lines().collect::<Vec<_>>().windows(4).any(|w| {
+            w[0].trim() == "\"\"\""
+                && w[1].trim() == expected_desc
+                && w[2].trim() == "\"\"\""
+                && w[3].trim().starts_with(arg_name)
+        })
     }
 
     assert!(
@@ -769,11 +766,7 @@ fn test_arg_descriptions_via_attr_and_doc_comment() {
         "expected times arg description in SDL:\n{sdl}"
     );
     assert!(
-        has_arg_desc(
-            &sdl,
-            "greeting",
-            "the salutation, e.g. 'hi' or 'hello'"
-        ),
+        has_arg_desc(&sdl, "greeting", "the salutation, e.g. 'hi' or 'hello'"),
         "expected greeting arg description in SDL:\n{sdl}"
     );
 }

--- a/derive/tests/resolved_object/resolved_object_args_tests.rs
+++ b/derive/tests/resolved_object/resolved_object_args_tests.rs
@@ -722,11 +722,7 @@ fn test_arg_descriptions_via_attr_and_doc_comment() {
         ///
         /// * `name` — the name of the person to greet.
         /// * `times` — how many times to repeat.
-        fn greet_via_doc(
-            &self,
-            #[graphql(desc = "the name of the person to greet")] name: String,
-            #[graphql(desc = "how many times to repeat")] times: i32,
-        ) -> String {
+        fn greet_via_doc(&self, name: String, times: i32) -> String {
             name.repeat(times as usize)
         }
 
@@ -754,7 +750,7 @@ fn test_arg_descriptions_via_attr_and_doc_comment() {
         * `name` — the name of the person to greet.
         * `times` — how many times to repeat.
       """
-      greetViaDoc("the name of the person to greet" name: String!, "how many times to repeat" times: Int!): String!
+      greetViaDoc(name: String!, times: Int!): String!
       """
         `desc` attribute wins over a generic doc comment when both are
         present (only the `desc` attribute is set here so we can verify
@@ -785,14 +781,6 @@ fn test_arg_descriptions_via_attr_and_doc_comment() {
         })
     }
 
-    assert!(
-        has_arg_desc(&sdl, "name", "the name of the person to greet"),
-        "expected name arg description in SDL:\n{sdl}"
-    );
-    assert!(
-        has_arg_desc(&sdl, "times", "how many times to repeat"),
-        "expected times arg description in SDL:\n{sdl}"
-    );
     assert!(
         has_arg_desc(&sdl, "greeting", "the salutation, e.g. 'hi' or 'hello'"),
         "expected greeting arg description in SDL:\n{sdl}"

--- a/derive/tests/resolved_object/resolved_object_args_tests.rs
+++ b/derive/tests/resolved_object/resolved_object_args_tests.rs
@@ -709,3 +709,71 @@ async fn test_query_numbers() {
         r#"Invalid value for argument "name": Failed to parse "Int": Only integers from 0 to 255 are accepted for u8."#,
     );
 }
+
+#[test]
+fn test_arg_descriptions_via_attr_and_doc_comment() {
+    #[derive(ResolvedObject)]
+    #[graphql(root)]
+    struct Query;
+
+    #[ResolvedObjectFields]
+    impl Query {
+        /// Greeter.
+        ///
+        /// * `name` — the name of the person to greet.
+        /// * `times` — how many times to repeat.
+        fn greet_via_doc(
+            &self,
+            #[graphql(desc = "the name of the person to greet")] name: String,
+            #[graphql(desc = "how many times to repeat")] times: i32,
+        ) -> String {
+            name.repeat(times as usize)
+        }
+
+        /// `desc` attribute wins over a generic doc comment when both are
+        /// present (only the `desc` attribute is set here so we can verify
+        /// it lands in the schema).
+        fn greet_via_attr(
+            &self,
+            #[graphql(desc = "the salutation, e.g. 'hi' or 'hello'")] greeting: String,
+        ) -> String {
+            greeting
+        }
+    }
+
+    #[derive(App)]
+    struct App(Query);
+
+    let sdl = App::create_schema().finish().unwrap().sdl();
+
+    // Each arg description appears as a `"""…"""` block immediately above
+    // the arg in the SDL, separate from the field's own description.
+    fn has_arg_desc(sdl: &str, arg_name: &str, expected_desc: &str) -> bool {
+        sdl.lines()
+            .collect::<Vec<_>>()
+            .windows(4)
+            .any(|w| {
+                w[0].trim() == "\"\"\""
+                    && w[1].trim() == expected_desc
+                    && w[2].trim() == "\"\"\""
+                    && w[3].trim().starts_with(arg_name)
+            })
+    }
+
+    assert!(
+        has_arg_desc(&sdl, "name", "the name of the person to greet"),
+        "expected name arg description in SDL:\n{sdl}"
+    );
+    assert!(
+        has_arg_desc(&sdl, "times", "how many times to repeat"),
+        "expected times arg description in SDL:\n{sdl}"
+    );
+    assert!(
+        has_arg_desc(
+            &sdl,
+            "greeting",
+            "the salutation, e.g. 'hi' or 'hello'"
+        ),
+        "expected greeting arg description in SDL:\n{sdl}"
+    );
+}


### PR DESCRIPTION
`dynamic-graphql` already surfaces descriptions for object types, fields,
inputs, enums, and scalars (via doc comments and `#[graphql(...)]` attrs),
but arguments on object/interface methods have no way to carry a
description into the schema. The generated SDL always shows `arg: Type`
with no docstring above it, even when the user adds `#[graphql(desc = "...")]`
or a `#[doc = "..."]` attribute on the argument.

This PR adds two ways to set an argument's description:

1. **Explicit attribute** — matches the `async-graphql` convention:
   ```rust
   async fn greet(
       &self,
       #[graphql(desc = "the name of the person to greet")] name: String,
   ) -> String { ... }
   ```

2. **Doc-comment fallback** — `#[doc = "..."]` attached to the argument is
   picked up automatically (since stable Rust ≥1.78, `///` doc comments on
   function parameters are accepted and lower to `#[doc = "..."]`).

If both are present, the explicit `desc` attribute wins.

We use dynamic-graphql for our server APIs and this will make things significantly easier to document things. Happy to change anything you like. If it all looks good I would really appreciate your making a release we can upgrade to.  
